### PR TITLE
Ejecucion tareas concurrentes.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/_1_ejecucion_tareas_concurrentes/EjecutorTareas.java
+++ b/src/_1_ejecucion_tareas_concurrentes/EjecutorTareas.java
@@ -1,0 +1,27 @@
+package _1_ejecucion_tareas_concurrentes;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class EjecutorTareas {
+    public static void main(String[] args) {
+
+        //Creamos tres objetos ImpresorTareas.
+        ImpresorTareas tarea1 = new ImpresorTareas("Tarea1");
+        ImpresorTareas tarea2 = new ImpresorTareas("Tarea2");
+        ImpresorTareas tarea3 = new ImpresorTareas("Tarea3");
+
+        System.out.println("Iniciando Executor");
+
+        ExecutorService executorService = Executors.newCachedThreadPool();
+
+        //Iniciar las tres tareas.
+        executorService.execute(tarea1);
+        executorService.execute(tarea2);
+        executorService.execute(tarea3);
+
+        executorService.shutdown();
+
+        System.out.println("Tareas iniciadas, método main finalizado.");
+    }
+}

--- a/src/_1_ejecucion_tareas_concurrentes/ImpresorTareas.java
+++ b/src/_1_ejecucion_tareas_concurrentes/ImpresorTareas.java
@@ -1,0 +1,27 @@
+package _1_ejecucion_tareas_concurrentes;
+
+import java.security.SecureRandom;
+
+public class ImpresorTareas implements Runnable {
+
+    private final SecureRandom generador = new SecureRandom();
+    private final int sleepTime;
+    private final String nombreTarea;
+
+    public ImpresorTareas(String nombreTarea){
+        this.nombreTarea = nombreTarea;
+        this.sleepTime = generador.nextInt(5000);
+    }
+
+    @Override
+    public void run() {
+        try {
+            System.out.printf("%s se fue a dormir %d milisegundos%n%n",
+                    this.nombreTarea, this.sleepTime);
+            Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+            e.printStackTrace(System.out);
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
Este ejemplo muestra cómo ejecutar tareas concurrentes en Java utilizando la interfaz Runnable y la clase ExecutorService. Se proporcionan dos clases: ImpresorTareas e EjecutorTareas. La primera implementa la interfaz Runnable y define un método run() que duerme durante un tiempo aleatorio antes de imprimir un mensaje en la consola. La segunda clase utiliza ExecutorService para administrar la ejecución de varias instancias de ImpresorTareas.

El método main() de EjecutorTareas inicia tres instancias de ImpresorTareas y las envía al ExecutorService para su ejecución. Después de iniciar las tareas, el método shutdown() se llama en el ExecutorService para indicar que no se aceptarán más tareas y que el servicio puede comenzar a apagarse de manera ordenada. Una vez que todas las tareas se han completado, el servicio se detendrá automáticamente.